### PR TITLE
Adapt aca-py start readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,6 @@ Once the plugin config is filled up. It is possible to deploy the plugin inside 
 $ aca-py start \
     --plugin redis_queue \
     --plugin-config plugins-config.yaml \
-    -it redis_queue.inbound redis 0 -oq redis_queue.outbound.RedisOutboundQueue
+    -it redis_queue.inbound redis 0 -ot redis_queue.outbound
     # ... the remainder of your startup arguments
 ```


### PR DESCRIPTION
Adapt README example to change "old-school" `-oq` parameter into `-ot` parameter.