### PR TITLE
Fix outbound transit after acapy upgrade

### DIFF
--- a/redis_queue/v1_0/outbound.py
+++ b/redis_queue/v1_0/outbound.py
@@ -36,11 +36,11 @@ class RedisOutboundQueue(BaseOutboundTransport):
 
     def __init__(
         self,
-        wire_format: BaseWireFormat,
         root_profile: Profile,
+        **kwargs,
     ):
         """Initialize base queue type."""
-        super().__init__(wire_format, root_profile)
+        super().__init__(**kwargs)
         self.outbound_config = (
             get_config(root_profile.context.settings).outbound
             or OutboundConfig.default()


### PR DESCRIPTION
After learning about the plugin and how to test it properly I realized the custom outbound transit broke with the acapy upgrade. I think the order of the wire_format and root_profile parameters must have changed and it wasn't using named arguments. I fixed it by copying how the http outbound in acapy was using the base class.